### PR TITLE
reverse cron_cmd settings in the conditional to use the correct command

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -82,9 +82,9 @@ class wal_e::install{
 
   #now config cron job if it is enabled
   if $wal_e::base_backup_purge_enabled {
-    $cron_cmd = "${::wal_e::env_dir}/base_backup.sh"
-  } else {
     $cron_cmd = "${::wal_e::env_dir}/base_backup.sh && ${::wal_e::env_dir}/purge_base_backup.sh"
+  } else {
+    $cron_cmd = "${::wal_e::env_dir}/base_backup.sh"
   }
   if $::wal_e::base_backup_enabled {
     $base_cron_ensure = 'present'


### PR DESCRIPTION
based on the base_backup_purge_enabled boolean.  logic is currently reversed so if base_backup_purge_enabled is set to false then the purge is enabled.
